### PR TITLE
Fix observer mutation name when format: json is used

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -34,8 +34,9 @@ export default class {
     let msg = event
     if (this.format === 'json' && event.data) {
       msg = JSON.parse(event.data)
-      target = [msg.namespace || '', msg.mutation].filter((e) => !!e).join('/')
-      if (msg.action) {
+      if (msg.mutation) {
+        target = [msg.namespace || '', msg.mutation].filter((e) => !!e).join('/')
+      } else if (msg.action) {
         method = 'dispatch'
         target = msg.action
       }


### PR DESCRIPTION
Hello Nathan,

Thanks for your lib, I really appreciate your work.

Hovewer I ran into an issue when I use `format: json` option.
Indeed, according to the documentation: "If there is a .mutation value in the
response data, the corresponding mutation is called with the name
SOCKET_[mutation value]"

However when event data does not contains .mutation value mutation is
null, so the mutation is not find in the store.

The behavior I expect is when `.mutation` value is not included in the data sent from the server, then I kept the original mutation methods.

What do you think?