### PR TITLE
Feature handle skip scheme ws url

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -3,6 +3,10 @@ import Emitter from './Emitter'
 export default class {
   constructor (connectionUrl, opts = {}) {
     this.format = opts.format && opts.format.toLowerCase()
+    if(connectionUrl.startsWith('//')){
+      const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      connectionUrl = `${scheme}://${connectionUrl}`
+    }
     this.connectionUrl = connectionUrl
     this.opts = opts
 

--- a/test/unit/specs/Observer.spec.js
+++ b/test/unit/specs/Observer.spec.js
@@ -23,6 +23,20 @@ describe('Observer.js', () => {
     }, vm)
   })
 
+  it('fires onopen event skip scheme', (done) => {
+    mockServer = new Server(wsUrl)
+    mockServer.on('connection', ws => {
+      ws.send('hi')
+    })
+    Vue.use(VueNativeSock, '//localhost:8080')
+    let vm = new Vue()
+    observer = new Observer(wsUrl)
+    Emitter.addListener('onopen', (data) => {
+      expect(data.type).to.equal('open')
+      mockServer.stop(done)
+    }, vm)
+  })
+
   // TODO: DRY
   it('passes a json commit to the provided vuex store', (done) => {
     let expectedMsg = { mutation: 'setName', value: 'steve' }


### PR DESCRIPTION
Hi.
I add support for schemeless URL. ie, `//localhost:8080/ws/`.

if `vue-native-websocket ` work on `http://` page, scheme set `ws://`.
if `vue-native-websocket ` work on `https://` page, scheme set `wss://`.
