### PR TITLE
add support for custom mutation name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ import VueNativeSock from 'vue-native-websocket'
 Vue.use(VueNativeSock, 'ws://localhost:9090', { protocol: 'my-protocol' })
 ```
 
-
 Optionally enable JSON message passing:
 
 ``` js
@@ -164,6 +163,67 @@ export default new Vuex.Store({
   }
 })
 ```
+
+##### With custom mutation names
+
+``` js
+// store.js
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+Vue.use(Vuex);
+
+export default new Vuex.Store({
+  state: {
+    socket: {
+      isConnected: false,
+      message: '',
+      reconnectError: false,
+    }
+  },
+  mutations:{
+    SOCKET_ONOPEN (state, event)  {
+      state.socket.isConnected = true
+    },
+    SOCKET_ONCLOSE (state, event)  {
+      state.socket.isConnected = false
+    },
+    SOCKET_ONERROR (state, event)  {
+      console.error(state, event)
+    },
+    // default handler called for all methods
+    SOCKET_ONMESSAGE (state, message)  {
+      state.socket.message = message
+    },
+    // mutations for reconnect methods
+    SOCKET_RECONNECT(state, count) {
+      console.info(state, count)
+    },
+    SOCKET_RECONNECT_ERROR(state) {
+      state.socket.reconnectError = true;
+    },
+  }
+})
+
+// index.js
+import store from './store'
+
+const mutations = {
+    SOCKET_ONOPEN: '✅ Socket connected!',
+    SOCKET_ONCLOSE: '❌ Socket disconnected!',
+    SOCKET_ONERROR: '❌ Socket Error!!!',
+    SOCKET_ONMESSAGE: 'Websocket message received',
+    SOCKET_RECONNECT: 'Websocket reconnected',
+    SOCKET_RECONNECT_ERROR: 'Websocket is having issues reconnecting..'
+};
+
+Vue.use(VueNativeSock, 'ws://localhost:9090', {
+    store: store,
+    format: 'json',
+    mutations: mutations
+})
+```
+
 
 ##### With `format: 'json'` enabled
 

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -15,6 +15,7 @@ export default class {
     this.connect(connectionUrl, opts)
 
     if (opts.store) { this.store = opts.store }
+    if (opts.mutations) { this.mutations = opts.mutations }
     this.onEvent()
   }
 
@@ -74,6 +75,10 @@ export default class {
         target = [msg.namespace || '', msg.action].filter((e) => !!e).join('/')
       }
     }
-    this.store[method](target, msg)
+    if (this.mutations) {
+        this.store[this.mutations[method] || method](target, msg)
+    } else {
+        this.store[method](target, msg)
+    }
   }
 }


### PR DESCRIPTION
```js
const mutationTypes = {
    LOGIN_PENDING: '🔒 Login Pending',
    LOGIN_SUCCESS: '🔒 ✅ Login Successful',
    LOGIN_FAILED: '🔒 ❌ Login Failed',
    LOGOUT: '🔒 Logout',
    REFRESH_TOKEN: '🔒 Refresh Token',
    REMOVE_AUTH_ERROR: '🔒 Remove Auth Error',
    ADD_CONFIG: '⚙️ Global config added to store',
    ADD_SHOW: '📺 Show added to store'
};
```

For example in an app I work on we have mutation names like this. It'd be nice to see the websocket ones displayed in the same way. This would also allow users to just hook up the websocket events to mutations they're already using.