### PR TITLE
Updated manual connect to accept alternative connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ Vue.use(VueNativeSock, 'ws://localhost:9090', {
   connectManually: true,
 })
 const vm = new Vue()
+// Connect to the websocket target specified in the configuration
 vm.$connect()
+// Connect to an alternative websocket URI
+vm.$connect('ws://localhost:9090/alternative/connection/')
 // do stuff with WebSockets
 vm.$disconnect()
 ```

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Vue.use(VueNativeSock, 'ws://localhost:9090', {
 const vm = new Vue()
 // Connect to the websocket target specified in the configuration
 vm.$connect()
-// Connect to an alternative websocket URI
-vm.$connect('ws://localhost:9090/alternative/connection/')
+// Connect to an alternative websocket URL and Options e.g.
+vm.$connect('ws://localhost:9090/alternative/connection/', { format: 'json' })
 // do stuff with WebSockets
 vm.$disconnect()
 ```

--- a/src/Main.js
+++ b/src/Main.js
@@ -13,7 +13,10 @@ export default {
     }
 
     if (opts.connectManually) {
-      Vue.prototype.$connect = () => {
+      Vue.prototype.$connect = (connectionAlternative) => {
+        if (connectionAlternative) {
+          connection = connectionAlternative
+        }
         observer = new Observer(connection, opts)
         Vue.prototype.$socket = observer.WebSocket
       }

--- a/src/Main.js
+++ b/src/Main.js
@@ -13,11 +13,8 @@ export default {
     }
 
     if (opts.connectManually) {
-      Vue.prototype.$connect = (connectionAlternative) => {
-        if (connectionAlternative) {
-          connection = connectionAlternative
-        }
-        observer = new Observer(connection, opts)
+      Vue.prototype.$connect = (connectionUrl = connection, connectionOpts = opts) => {
+        observer = new Observer(connectionUrl, connectionOpts)
         Vue.prototype.$socket = observer.WebSocket
       }
 


### PR DESCRIPTION
Updated the manual-connect to accept `connectionAlternative` parameter so that you can change the websocket URI on the fly