### PR TITLE
No default connection string if connectManually

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -4,7 +4,7 @@ import Emitter from './Emitter'
 export default {
 
   install (Vue, connection, opts = {}) {
-    if (!connection) { throw new Error('[vue-native-socket] cannot locate connection') }
+    if (!connection && !opts.connectManually) { throw new Error('[vue-native-socket] cannot locate connection') }
 
     let observer = null
 


### PR DESCRIPTION
This adds the abillity to provide `null` instead of a default connection string when `connectManually` option is turned on.
```js
Vue.use(VueNativeSock, null, {
  store,
  connectManually: true
})
```

I got this use case for an app which can connect arbitrarily to the user's selected host.
Temporary workaround : set `ws://example.com` as a default connection string and use :
```js
Vue.prototype.$socket.$connect('ws://your_host.com')
```
to connect to any WebSocket server. This workaround is not ideal as you don't own the `example.com` domain.