### PR TITLE
Fix connection URL when resolving the scheme

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -6,7 +6,7 @@ export default class {
 
     if (connectionUrl.startsWith('//')) {
       const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
-      connectionUrl = `${scheme}://${connectionUrl}`
+      connectionUrl = `${scheme}:${connectionUrl}`
     }
 
     this.connectionUrl = connectionUrl


### PR DESCRIPTION
In case the `connectionUrl` already starts with `//` the `//` in the concatination is redundant.

This might be related to #87.