### PR TITLE
Add support for vuex actions in defaultPassToStore

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -1,5 +1,8 @@
 import Emitter from './Emitter'
 
+const commit = 'commit'
+const dispatch = 'dispatch'
+
 export default class {
   constructor (connectionUrl, opts = {}) {
     this.format = opts.format && opts.format.toLowerCase()
@@ -22,8 +25,18 @@ export default class {
 
     this.connect(connectionUrl, opts)
 
-    if (opts.store) { this.store = opts.store }
-    if (opts.mutations) { this.mutations = opts.mutations }
+    if (opts.store) {
+      if ((opts.storeMethodType && opts.storeMethodType == dispatch) || opts.storeMethodType === commit) {
+        this.storeMethodType = opts.storeMethodType
+      } else {
+        this.storeMethodType = commit
+      }
+    }
+    if (opts.mutations) {
+      console.warn('vue-native-websocket plugin: mutations will be deprecated, please switch to methods')
+      this.methods = opts.mutations
+    }
+    if (opts.methods) { this.methods = opts.methods }
     this.onEvent()
   }
 
@@ -82,21 +95,23 @@ export default class {
 
   defaultPassToStore (eventName, event) {
     if (!eventName.startsWith('SOCKET_')) { return }
-    let method = 'commit'
+    let method = this.storeMethodType
     let target = eventName.toUpperCase()
     let msg = event
     if (this.format === 'json' && event.data) {
       msg = JSON.parse(event.data)
       if (msg.mutation) {
+        method = commit
         target = [msg.namespace || '', msg.mutation].filter((e) => !!e).join('/')
       } else if (msg.action) {
-        method = 'dispatch'
+        method = dispatch
         target = [msg.namespace || '', msg.action].filter((e) => !!e).join('/')
       }
     }
-    if (this.mutations) {
-      target = this.mutations[target] || target
+    if (this.methods) {
+      target = this.methods[target] || target
     }
     this.store[method](target, msg)
   }
+}
 }

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -26,6 +26,7 @@ export default class {
     this.connect(connectionUrl, opts)
 
     if (opts.store) {
+      this.store = opts.store
       if ((opts.storeMethodType && opts.storeMethodType == dispatch) || opts.storeMethodType === commit) {
         this.storeMethodType = opts.storeMethodType
       } else {
@@ -113,5 +114,4 @@ export default class {
     }
     this.store[method](target, msg)
   }
-}
 }

--- a/test/unit/specs/Observer.spec.js
+++ b/test/unit/specs/Observer.spec.js
@@ -92,6 +92,36 @@ describe('Observer.js', () => {
   })
 
   // TODO: DRY
+  it('passes an action to the provided vuex store', (done) => {
+    let expectedMsg = 'hello world'
+    let mockStore = sinon.mock({ 
+      commit: () => {},
+      dispatch: () => {}
+    })
+    mockStore.expects('dispatch').withArgs('SOCKET_ONOPEN')
+    mockStore.expects('dispatch').withArgs('SOCKET_ONMESSAGE')
+
+    mockServer = new Server(wsUrl)
+    mockServer.on('connection', ws => {
+      ws.send(expectedMsg)
+    })
+
+    Vue.use(VueNativeSock, wsUrl)
+    let vm = new Vue()
+    observer = new Observer(wsUrl, {
+      store: mockStore.object,
+      storeMethodType: 'dispatch',
+      websocket: new WebSocket(wsUrl)
+    })
+
+    setTimeout(() => {
+      mockStore.verify()
+      mockServer.stop(done)
+    }, 100)
+  })
+
+
+  // TODO: DRY
   it('passes a namespaced json commit to the provided vuex store', (done) => {
     let expectedMsg = { namespace: 'users', mutation: 'setName', value: 'steve' }
     let mockStore = sinon.mock({ commit: () => {} })

--- a/test/unit/specs/Observer.spec.js
+++ b/test/unit/specs/Observer.spec.js
@@ -96,7 +96,9 @@ describe('Observer.js', () => {
     let expectedMsg = 'hello world'
     let mockStore = sinon.mock({ 
       commit: () => {},
-      dispatch: () => {}
+      dispatch: (event) => {
+        expect(event.data == expectedMsg)
+      }
     })
     mockStore.expects('dispatch').withArgs('SOCKET_ONOPEN')
     mockStore.expects('dispatch').withArgs('SOCKET_ONMESSAGE')


### PR DESCRIPTION
Hey I wanted to add support for dispatching actions (without formatting to json) so I took a crack at what that might look like.

This would default to mutations, and the `mutations` option will still work with a `console.warn` but eventually this library should move off that option and start using `methods`

If you want to go forward with this I could also update the readme to reflect this change as well.