### PR TITLE
Object.seal sometime gets undefined value

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -56,10 +56,9 @@ export default {
             })
           }
         } else {
-          Object.seal(this.$options.sockets)
-
           // if !hasProxy need addListener
           if (sockets) {
+            Object.seal(this.$options.sockets)
             Object.keys(sockets).forEach(key => {
               Emitter.addListener(key, sockets[key], vm)
             })

--- a/src/Main.js
+++ b/src/Main.js
@@ -55,14 +55,12 @@ export default {
               this.$options.sockets[key] = sockets[key]
             })
           }
-        } else {
+        } else if (sockets) {
           // if !hasProxy need addListener
-          if (sockets) {
-            Object.seal(this.$options.sockets)
-            Object.keys(sockets).forEach(key => {
-              Emitter.addListener(key, sockets[key], vm)
-            })
-          }
+          Object.seal(this.$options.sockets)
+          Object.keys(sockets).forEach(key => {
+            Emitter.addListener(key, sockets[key], vm)
+          })
         }
       },
       beforeDestroy () {


### PR DESCRIPTION
Hi,

I see strange the `sockets` option using which can be undefined if user didn't define it in `Vue` options. If I understand as right it may be a bug.

It can be related with this opened issue: https://github.com/nathantsoi/vue-native-websocket/issues/75

And the [Object.seal should get the object type](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal#Non-object_coercion). If it will be not object the ES5 code will throw `TypeError`. I didn't test it but i saw code and think that's should be patched.