### PR TITLE
Prevent reconnect after timeout for previously destroyed socket (with use $disconnect method)

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -20,7 +20,10 @@ export default {
       }
 
       Vue.prototype.$disconnect = () => {
-        if (observer && observer.reconnection) { observer.reconnection = false }
+        if (observer && observer.reconnection) { 
+          observer.reconnection = false
+          clearTimeout(observer.reconnectTimeoutId)
+         }
         if (Vue.prototype.$socket) {
           Vue.prototype.$socket.close()
           delete Vue.prototype.$socket


### PR DESCRIPTION
I fixed a bug when we manually close the connection with method `$disconnect()` but the connection restores after reconnecting timeout.

To reproduce this bug we need a closed connection that waits for reconnecting timeout. When we use the `$disconnect()` method in this case, connection restores after reconnect timeout is gone.